### PR TITLE
Added in additional cipher checks for youtube

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -394,7 +394,10 @@ export default class VideoPlayer
 			return;
 		}		
 
-		if (videoInfo.streamingData.adaptiveFormats[0].cipher || videoInfo.streamingData.adaptiveFormats[0].signatureCipher)
+		if (videoInfo.streamingData.adaptiveFormats[0].cipher || 
+			videoInfo.streamingData.adaptiveFormats[0].signatureCipher ||
+			videoInfo.streamingData.formats[0].cipher ||
+			videoInfo.streamingData.formats[0].signatureCipher)
 		{
 			this.showText("YoutubeCiphered");
 			return;


### PR DESCRIPTION
Found some additional info on detecting ciphered videos from YouTube.  Not sure what the deal with the qhitespace in the diff is, but looks right in my VS Code.