### PR TITLE
Fix for undefined formats property error

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -519,10 +519,16 @@ export default class VideoPlayer {
 			}
 		}
 
-		if (videoInfo.streamingData.adaptiveFormats[0].cipher ||
-			videoInfo.streamingData.adaptiveFormats[0].signatureCipher ||
-			videoInfo.streamingData.formats[0].cipher ||
-			videoInfo.streamingData.formats[0].signatureCipher)
+		if (
+			videoInfo.streamingData.adaptiveFormats && (
+				videoInfo.streamingData?.adaptiveFormats[0]?.cipher ||
+				videoInfo.streamingData?.adaptiveFormats[0]?.signatureCipher
+			) ||
+			videoInfo.streamingData.formats && (
+				videoInfo.streamingData?.formats[0]?.cipher ||
+				videoInfo.streamingData?.formats[0]?.signatureCipher
+			)
+		)
 		{
 			this.showLabel("YoutubeCiphered");
 			return;


### PR DESCRIPTION
This fixes the incorrect error for when the streaming data formats or adaptive formats are undefined from the YouTube video info fetch results.